### PR TITLE
Add `-fpermissive` to the `Makefile`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -413,7 +413,7 @@ ifeq ($(origin CXXFLAGS), undefined)
 
   ifeq ($(BUILDDEBUG), 1)
   else
-    CXXFLAGS += -O4 -funroll-loops -fexpensive-optimizations -finline-functions -fomit-frame-pointer
+    CXXFLAGS += -O4 -fpermissive -funroll-loops -fexpensive-optimizations -finline-functions -fomit-frame-pointer
   endif
 
   ifeq ($(BUILDJEMALLOC), 1)


### PR DESCRIPTION
To be able to compile everything and avoid the following error:

```
meryl2/merylOpTemplate.C: In member function ‘void merylOpTemplate::addPrinter(const char*, bool, std::vector<const char*>&)’:
meryl2/merylOpTemplate.C:167:26: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
  167 |   for (char *suf = strchr(prName, '#'); ((suf) && (*suf == '#')); suf++)
      |                    ~~~~~~^~~~~~~~~~~~~
      |                          |
      |                          const char*
```